### PR TITLE
Feature distinguish orientation

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,8 @@
 {
     "media" : {
-        "path": "media/"
+        "path": "media/",
+        "landscape": true,
+        "portrait": true
     },
     "position": {
         "x": 0,

--- a/picture_frame.py
+++ b/picture_frame.py
@@ -10,6 +10,8 @@ import exifread
 from geopy.geocoders import Nominatim
 import json
 from datetime import datetime
+from PIL import Image
+from moviepy.editor import VideoFileClip
 
 app = Flask(__name__)
 allFiles = []
@@ -21,6 +23,8 @@ with open("config.json") as file:
     config = json.load(file)
 
     media_path = config["media"]["path"]
+    show_portrait = config["media"]["portrait"]
+    show_landscape = config["media"]["landscape"]
     cache_path = config["cache"]["path"]
     cache_depth = config["cache"]["depth"]
     metadata_path = config["metadata"]["path"]
@@ -36,6 +40,63 @@ def is_media(file_path):
 def is_video(file_path):
     _, file_extension = os.path.splitext(file_path)
     return file_extension.lower() in (".mp4")
+
+
+def get_photo_rotation(file_path):
+    with open(file_path, 'rb') as img_file:
+        exif_tags = exifread.process_file(img_file)
+        orientation_key = 'Image Orientation'
+
+        if orientation_key in exif_tags:
+            orientation = exif_tags[orientation_key].values[0]
+            return orientation
+
+    return False
+
+def is_photo_landscape(file_path):
+    rotated = get_photo_rotation(file_path) in [5, 6, 7, 8]
+        
+    with Image.open(file_path) as img:
+        width, height = img.size
+        if rotated:
+            return height > width or width == height
+        else:
+            return width > height or width == height
+
+def get_video_rotation(file_path):
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-i", file_path, "-v", "quiet", 
+             "-print_format", "json", "-show_streams"],
+            stdout=subprocess.PIPE, 
+            stderr=subprocess.STDOUT
+        )
+        metadata = json.loads(result.stdout)
+        
+        for stream in metadata.get('streams', []):
+            if stream.get('codec_type') == 'video':
+                for side_data in stream.get('side_data_list', []):
+                    if side_data.get('side_data_type') == 'Display Matrix':
+                        return side_data.get('rotation', 0)
+        return 0
+    except Exception as e:
+        print(f"Error extracting metadata for {file_path}: {e}")
+        return 0
+
+def is_video_landscape(file_path):
+    rotation = get_video_rotation(file_path)
+    if rotation in [90, 270, -90, -270]:
+        return False
+    else:
+        with VideoFileClip(file_path) as video:
+            width, height = video.size
+            return width > height
+
+def is_landscape(file_path):
+    if (is_video(file_path)):
+        return is_video_landscape(file_path)
+    else:
+        return is_photo_landscape(file_path)
 
 def index_files():
     num_excluded = 0
@@ -137,8 +198,15 @@ def new_cache():
 
     try:
         shutil.copy2(source, destination)
-        cached_files.append(picked)
-        print("Cached: " + picked + " - Cache size: " + str(len(cached_files)))
+        landscape = is_landscape(os.path.join(cache_path, picked))
+        if (show_landscape and landscape) or (show_portrait and not landscape):
+            cached_files.append(picked)
+            print("Cached: " + picked + " - Cache size: " + str(len(cached_files)))
+        else:
+            print("Undesired orientation: " + picked)
+            os.remove(os.path.join(cache_path, picked))
+            allFiles.remove(picked)
+            new_cache()
     except:
         print("Caching failed: " + picked)
         new_cache()


### PR DESCRIPTION
The desired orientation(s) can be set in the config, and the orientation of each file is checked when it gets cached and is then stored in the metadata so it does not need to be checked again later.  For this the metadata was changed to run on a single seperate thread, instead of having multiple threads edit the file at the same time which would lead to issues.